### PR TITLE
✨ add: 複数の言語モデルサポートを追加

### DIFF
--- a/.commit-message-config.sample
+++ b/.commit-message-config.sample
@@ -1,0 +1,31 @@
+# サンプル設定ファイル
+# このファイルを .commit-message-config としてプロジェクトルートに配置するか
+# ${HOME}/.commit-message-config に配置して使用します
+
+# AIプロバイダー設定 (bedrock, openai, anthropic, ollama)
+PROVIDER="bedrock"
+
+# モデルID
+# Bedrock: amazon.nova-pro-v1:0, anthropic.claude-instant-v1, ai21.j2-ultra など
+# OpenAI: gpt-4, gpt-3.5-turbo など
+# Anthropic: claude-3-opus-20240229, claude-3-sonnet-20240229 など
+# Ollama: llama2, mistral, gemma など
+MODEL_ID="amazon.nova-pro-v1:0"
+
+# AWS Bedrock用の設定 (PROVIDERがbedrockの場合に使用)
+AWS_REGION="us-east-1"
+
+# 生成パラメータ
+TEMPERATURE="0.5"  # 生成の温度 (0.0～1.0)
+MAX_TOKENS="512"   # 最大トークン数
+TOP_P="0.9"        # 上位確率 (多様性)
+
+# 言語設定 (ja, en)
+LANGUAGE="ja"
+
+# Ollama用のホスト設定 (PROVIDERがollamaの場合に使用)
+OLLAMA_HOST="http://localhost:11434"
+
+# 以下の環境変数はこのファイルではなく、環境変数として設定することを推奨します
+# OPENAI_API_KEY="your_openai_api_key"
+# ANTHROPIC_API_KEY="your_anthropic_api_key"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - **Git**: バージョン 2.20.0 以上推奨
 - **bash または互換シェル**: スクリプト実行環境
 - **jq**: JSON 処理用（インストールされていない場合は `apt-get install jq` や `brew install jq` でインストール）
-- **curl**: API呼び出し用（ほとんどのシステムにプリインストールされています）
+- **curl**: API呼び出し用（OpenAI、Anthropic、Ollamaプロバイダー使用時に必要）
 
 以下は選択したAIプロバイダーによって必要になります：
 - **AWS CLI と Bedrock アクセス**: Amazon Bedrockを使用する場合
@@ -35,7 +35,7 @@ cd git-commit-message-generator
 2. 設定ファイルを作成します：
 
 ```bash
-cp .commit-message-config.sample .commit-message-config
+cp .commit-message-config.example .commit-message-config
 ```
 
 3. 設定ファイルを編集して、使用するAIプロバイダーやモデルを設定します：
@@ -45,6 +45,7 @@ cp .commit-message-config.sample .commit-message-config
 PROVIDER="bedrock"
 MODEL_ID="amazon.nova-pro-v1:0"
 AWS_REGION="us-east-1"
+# 他の設定パラメータも必要に応じて変更可能
 ```
 
 4. 選択したプロバイダーに応じて必要な認証情報を設定します：
@@ -52,6 +53,22 @@ AWS_REGION="us-east-1"
 - Amazon Bedrock:
   ```bash
   aws configure
+  ```
+  
+- OpenAI:
+  ```bash
+  export OPENAI_API_KEY="your_openai_api_key_here"
+  ```
+  
+- Anthropic:
+  ```bash
+  export ANTHROPIC_API_KEY="your_anthropic_api_key_here"
+  ```
+  
+- Ollama:
+  ```bash
+  # デフォルトでは http://localhost:11434 を使用
+  # リモートサーバーの場合は設定ファイルで OLLAMA_HOST を変更
   ```
 
 - OpenAI API:
@@ -85,6 +102,19 @@ $ git commit -m "$(bash generate_commit_message.sh)"
 [main 3a21f8e] ✨ add: READMEに複数AIプロバイダーのサポートを追加
 
 - Amazon Bedrock, OpenAI, Anthropic, Ollamaの使用方法を記載
+```
+
+#### プロバイダーの一時的な切り替え
+
+コマンドライン上で別のプロバイダーを一時的に使用することも可能です：
+
+```bash
+# OpenAIを一時的に使用
+PROVIDER=openai MODEL_ID=gpt-4 git commit -m "$(bash generate_commit_message.sh)"
+
+# Anthropicを一時的に使用
+PROVIDER=anthropic MODEL_ID=claude-3-sonnet-20240229 git commit -m "$(bash generate_commit_message.sh)"
+```
 - 設定ファイルのサンプルと説明を追加
 - 各プロバイダーごとの認証情報設定手順を明確化
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd git-commit-message-generator
 2. 設定ファイルを作成します：
 
 ```bash
-cp .commit-message-config.example .commit-message-config
+cp .commit-message-config.sample .commit-message-config
 ```
 
 3. 設定ファイルを編集して、使用するAIプロバイダーやモデルを設定します：

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Git コミットメッセージ自動生成ツール
 
-このツールは、Git のフック機能と Amazon Bedrock の言語モデルを組み合わせて、一貫性のあるフォーマットでコミットメッセージを自動生成します。開発者の手間を省きながら、プロジェクト全体で統一されたコミットメッセージを維持することができます。変更内容を自動で分析し、適切な説明文を生成することで、コード管理の効率と質を向上させます。
+このツールは、Git のフック機能と各種言語モデルを組み合わせて、一貫性のあるフォーマットでコミットメッセージを自動生成します。開発者の手間を省きながら、プロジェクト全体で統一されたコミットメッセージを維持することができます。変更内容を自動で分析し、適切な説明文を生成することで、コード管理の効率と質を向上させます。
 
 ## 特徴
 
@@ -8,14 +8,20 @@
 - **一貫性**: プロジェクト全体で統一されたコミットメッセージフォーマットを維持
 - **カスタマイズ可能**: プロジェクトやチームの要件に合わせてメッセージスタイルを調整可能
 - **Git フック統合**: 通常の Git ワークフローにシームレスに統合
+- **複数の言語モデルサポート**: Amazon Bedrock、OpenAI API、Anthropic、Ollamaなど様々なAIプロバイダーに対応
 
 ## 前提条件
 
 - **Git**: バージョン 2.20.0 以上推奨
-- **AWS CLI**: バージョン 2.0 以上、適切に設定済みであること
-- **Amazon Bedrock アクセス**: 適切な IAM 権限が設定されていること
 - **bash または互換シェル**: スクリプト実行環境
 - **jq**: JSON 処理用（インストールされていない場合は `apt-get install jq` や `brew install jq` でインストール）
+- **curl**: API呼び出し用（ほとんどのシステムにプリインストールされています）
+
+以下は選択したAIプロバイダーによって必要になります：
+- **AWS CLI と Bedrock アクセス**: Amazon Bedrockを使用する場合
+- **OpenAI API キー**: OpenAI APIを使用する場合
+- **Anthropic API キー**: Anthropic Claude APIを直接使用する場合
+- **Ollama**: ローカルモデルを使用する場合
 
 ## インストールと設定
 
@@ -26,25 +32,40 @@ git clone https://github.com/yourusername/git-commit-message-generator.git
 cd git-commit-message-generator
 ```
 
-2. AWS CLI が正しく設定されていることを確認します：
+2. 設定ファイルを作成します：
 
 ```bash
-aws configure list
+cp .commit-message-config.sample .commit-message-config
 ```
 
-必要な場合は以下のコマンドで設定してください：
+3. 設定ファイルを編集して、使用するAIプロバイダーやモデルを設定します：
 
 ```bash
-aws configure
+# PROVIDER には bedrock, openai, anthropic, ollama のいずれかを指定
+PROVIDER="bedrock"
+MODEL_ID="amazon.nova-pro-v1:0"
+AWS_REGION="us-east-1"
 ```
 
-3. generate_commit_message.sh スクリプトを編集して、使用する Bedrock モデルとリージョンを設定します：
+4. 選択したプロバイダーに応じて必要な認証情報を設定します：
 
-```bash
-# スクリプト内の以下の部分を編集
-MODEL_ID="anthropic.claude-v2"
-AWS_REGION="us-west-2"
-```
+- Amazon Bedrock:
+  ```bash
+  aws configure
+  ```
+
+- OpenAI API:
+  ```bash
+  export OPENAI_API_KEY="your-api-key"
+  ```
+
+- Anthropic API:
+  ```bash
+  export ANTHROPIC_API_KEY="your-api-key"
+  ```
+
+- Ollama:
+  ローカルでOllamaを起動し、.commit-message-configファイル内でOLLAMA_HOSTを設定
 
 ## 使用方法
 
@@ -53,23 +74,28 @@ AWS_REGION="us-west-2"
 コミット時に以下のコマンドを実行することで、生成されたメッセージを直接使用できます：
 
 ```bash
-git commit -m "$(bash generate_commit_message.sh | tr -d '"')"
+git commit -m "$(bash generate_commit_message.sh)"
 ```
 
 #### 実行例
 
 ```
 $ git add README.md
-$ git commit -m "$(bash generate_commit_message.sh | tr -d '"')"
-[main 3a21f8e] READMEを更新: インストール手順を明確化し、使用例を追加
+$ git commit -m "$(bash generate_commit_message.sh)"
+[main 3a21f8e] ✨ add: READMEに複数AIプロバイダーのサポートを追加
+
+- Amazon Bedrock, OpenAI, Anthropic, Ollamaの使用方法を記載
+- 設定ファイルのサンプルと説明を追加
+- 各プロバイダーごとの認証情報設定手順を明確化
 ```
 
 ### 方法 2: Git フックとして利用
 
-1. commit-msg ファイルを .git/hooks/ ディレクトリにコピーします：
+1. commit-msg ファイルとconfig.shを .git/hooks/ ディレクトリにコピーします：
 
 ```bash
-cp commit-msg .git/hooks/
+cp commit-msg config.sh .commit-message-config.sample .git/hooks/
+cp .commit-message-config .git/hooks/ # 既に設定済みの場合
 ```
 
 2. フックファイルに実行権限を付与します：
@@ -87,11 +113,53 @@ git commit
 このセットアップにより、コミット時に自動的に AI 生成されたメッセージが適用されます。エディタが開いた際に、AI 生成メッセージが既に入力されていることを確認できます。
 
 生成されたメッセージが気に入らない場合：
-
 - エディタで直接編集して保存
 - または後から `git commit --amend` でコミットメッセージを修正
 
+## AIプロバイダーの設定
+
+### Amazon Bedrock
+
+```
+PROVIDER="bedrock"
+MODEL_ID="amazon.nova-pro-v1:0"  # または anthropic.claude-v2 など
+AWS_REGION="us-east-1"
+```
+
+### OpenAI API
+
+```
+PROVIDER="openai"
+MODEL_ID="gpt-3.5-turbo"  # または gpt-4 など
+OPENAI_API_KEY="your-api-key"  # 環境変数として設定推奨
+```
+
+### Anthropic Claude API
+
+```
+PROVIDER="anthropic"
+MODEL_ID="claude-3-sonnet-20240229"  # または claude-3-opus-20240229 など
+ANTHROPIC_API_KEY="your-api-key"  # 環境変数として設定推奨
+```
+
+### Ollama (ローカルモデル)
+
+```
+PROVIDER="ollama"
+MODEL_ID="llama2"  # または mistral, gemma など
+OLLAMA_HOST="http://localhost:11434"
+```
+
 ## カスタマイズ
+
+### 設定ファイル
+
+設定は以下の優先順位で読み込まれます：
+
+1. 環境変数（`PROVIDER_ENV`, `MODEL_ID_ENV`など）
+2. プロジェクト設定ファイル（`.commit-message-config`）
+3. ユーザーホーム設定ファイル（`$HOME/.commit-message-config`）
+4. デフォルト設定
 
 ### プロンプトのカスタマイズ
 
@@ -99,29 +167,36 @@ generate_commit_message.sh スクリプト内のプロンプト部分を編集�
 
 ```bash
 # 例: より詳細なメッセージを生成するプロンプト
-PROMPT="以下の Git 差分を分析し、変更内容を要約した簡潔かつ詳細なコミットメッセージを生成してください。
+prompt=$(cat <<EOF | jq -sR .
+以下の Git 差分を分析し、変更内容を要約した簡潔かつ詳細なコミットメッセージを生成してください。
 - タイトルは50文字以内
 - 詳細な説明は72文字で改行
 - 変更理由と影響についても言及
 - 関連するチケット番号があれば含める
 
 git diff:
-$GIT_DIFF"
+EOF
+)
 ```
 
 ## トラブルシューティング
 
-### AWS 認証エラー
+### API認証エラー
 
 ```
 An error occurred (AccessDeniedException) when calling the InvokeModel operation
 ```
 
-解決策:
+または
 
-- AWS CLI の設定が正しいか確認: `aws configure list`
-- IAM ユーザーに適切な Bedrock 権限があるか確認
-- AWS_PROFILE 環境変数を設定: `export AWS_PROFILE=your-profile`
+```
+Error: 401 Unauthorized
+```
+
+解決策:
+- 選択したプロバイダーの認証情報が正しく設定されているか確認
+- API キーの有効期限や利用制限を確認
+- プロバイダーのサービスステータスを確認
 
 ### スクリプト実行エラー
 
@@ -135,17 +210,17 @@ An error occurred (AccessDeniedException) when calling the InvokeModel operation
 chmod +x generate_commit_message.sh
 ```
 
-### 生成されたメッセージの品質問題
+### 特定のモデルやプロバイダーの問題
 
-- プロンプトを調整して、より詳細な指示を追加
-- 異なる Bedrock モデルを試す（例: Claude 3 はより高品質な結果を生成）
-- 差分のサイズが大きすぎる場合は、小さな単位でコミットを行う
+- 別のモデルやプロバイダーを試す
+- 各サービスの公式ドキュメントを参照
+- モデルのパラメータ（温度など）を調整
 
 ## セキュリティに関する注意点
 
-- スクリプトは AWS 認証情報を使用するため、認証情報の適切な管理が重要です
+- API キーは環境変数として設定し、設定ファイルには直接書かないようにしましょう
 - 機密コードを含む差分はクラウドサービスに送信されるため、内部プロジェクトでは注意が必要です
-- AWS IAM ポリシーを適切に設定し、必要最小限の権限を付与してください
+- 適切なIAMポリシーやAPI利用制限を設定し、必要最小限の権限を付与してください
 
 ## 貢献方法
 

--- a/commit-msg
+++ b/commit-msg
@@ -3,9 +3,31 @@
 commit_msg_file=$1
 commit_msg=$(cat "$commit_msg_file")
 
+# 設定ファイルを読み込み
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+if [ -f "$script_dir/config.sh" ]; then
+  source "$script_dir/config.sh"
+else
+  # 設定ファイルがない場合はデフォルト値を設定
+  PROVIDER="bedrock"
+  MODEL_ID="amazon.nova-pro-v1:0"
+  AWS_REGION="us-east-1"
+  TEMPERATURE="0.5"
+  MAX_TOKENS="512"
+  TOP_P="0.9"
+  LANGUAGE="ja"
+fi
+
 git_diff=$(git diff HEAD | jq -sR .)
+
+# 言語設定に基づいてプロンプトを調整
+prompt_lang="日本語"
+if [ "$LANGUAGE" = "en" ]; then
+  prompt_lang="英語"
+fi
+
 prompt=$(cat <<EOF | jq -sR .
-コミットメッセージを日本語で作成してください。このとき、コミットメッセージのみを返してください。コミットメッセージのprefixとして「feat: 新機能の追加」のように変更内容に応じてprefixをつけてください。プレフィックスには<prefix>タグ内の値を利用してください。
+コミットメッセージを${prompt_lang}で作成してください。このとき、コミットメッセージのみを返してください。コミットメッセージのprefixとして「feat: 新機能の追加」のように変更内容に応じてprefixをつけてください。プレフィックスには<prefix>タグ内の値を利用してください。
 <prefix>
 - 🐛 fix：バグ修正
 - 🚨 hotfix：クリティカルなバグ修正
@@ -55,11 +77,97 @@ feat: ホームページに検索窓を追加
 EOF
 )
 
-msg=$(aws bedrock-runtime converse \
---model-id amazon.nova-pro-v1:0 \
---messages "[{\"role\":\"user\",\"content\":[{\"text\":$prompt}]},{\"role\":\"user\",\"content\":[{\"text\": $(echo "$commit_msg $git_diff" | jq -R -s .)}]}]" \
---inference-config '{"maxTokens": 512, "temperature": 0.5, "topP": 0.9}' | jq .output.message.content[0].text)
+# 依存コマンドの確認
+check_dependency() {
+  if ! command -v "$1" &> /dev/null; then
+    echo "エラー: $1 がインストールされていません" >&2
+    exit 1
+  fi
+}
 
-echo -e $(echo $msg | tr -d '"' | sed 's/^```//') > "$commit_msg_file"
+check_dependency jq
+check_dependency git
+
+# AIプロバイダーに基づいてリクエストを作成
+case "$PROVIDER" in
+  bedrock)
+    check_dependency aws
+    response=$(aws bedrock-runtime converse \
+      --model-id "$MODEL_ID" \
+      --region "$AWS_REGION" \
+      --messages "[{\"role\":\"user\",\"content\":[{\"text\":$prompt}]},{\"role\":\"user\",\"content\":[{\"text\": $(echo "$commit_msg $git_diff" | jq -R -s .)}]}]" \
+      --inference-config "{\"maxTokens\": $MAX_TOKENS, \"temperature\": $TEMPERATURE, \"topP\": $TOP_P}")
+    msg=$(echo "$response" | jq .output.message.content[0].text)
+    ;;
+    
+  openai)
+    check_dependency curl
+    if [ -z "$OPENAI_API_KEY" ]; then
+      echo "エラー: OPENAI_API_KEYが設定されていません" >&2
+      exit 1
+    fi
+    
+    response=$(curl -s -X POST "https://api.openai.com/v1/chat/completions" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $OPENAI_API_KEY" \
+      -d "{
+        \"model\": \"$MODEL_ID\",
+        \"messages\": [
+          {\"role\": \"user\", \"content\": $(echo "$prompt" | jq -R .)},
+          {\"role\": \"user\", \"content\": $(echo "$commit_msg $git_diff" | jq -R .)}
+        ],
+        \"temperature\": $TEMPERATURE,
+        \"max_tokens\": $MAX_TOKENS
+      }")
+    msg=$(echo "$response" | jq -r '.choices[0].message.content' | jq -R .)
+    ;;
+    
+  anthropic)
+    check_dependency curl
+    if [ -z "$ANTHROPIC_API_KEY" ]; then
+      echo "エラー: ANTHROPIC_API_KEYが設定されていません" >&2
+      exit 1
+    fi
+    
+    response=$(curl -s -X POST "https://api.anthropic.com/v1/messages" \
+      -H "Content-Type: application/json" \
+      -H "x-api-key: $ANTHROPIC_API_KEY" \
+      -H "anthropic-version: 2023-06-01" \
+      -d "{
+        \"model\": \"$MODEL_ID\",
+        \"messages\": [
+          {\"role\": \"user\", \"content\": $(echo "$prompt $commit_msg $git_diff" | jq -R .)}
+        ],
+        \"max_tokens\": $MAX_TOKENS,
+        \"temperature\": $TEMPERATURE
+      }")
+    msg=$(echo "$response" | jq -r '.content[0].text' | jq -R .)
+    ;;
+    
+  ollama)
+    check_dependency curl
+    if [ -z "$OLLAMA_HOST" ]; then
+      OLLAMA_HOST="http://localhost:11434"
+    fi
+    
+    response=$(curl -s -X POST "$OLLAMA_HOST/api/generate" \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"model\": \"$MODEL_ID\",
+        \"prompt\": $(echo "$prompt\n\n$commit_msg\n\n$git_diff" | jq -R .),
+        \"temperature\": $TEMPERATURE,
+        \"stream\": false
+      }")
+    msg=$(echo "$response" | jq -r '.response' | jq -R .)
+    ;;
+    
+  *)
+    echo "エラー: サポートされていないAIプロバイダーです: $PROVIDER" >&2
+    exit 1
+    ;;
+esac
+
+# 回答からMarkdownの記号などを除去してコミットメッセージに書き込む
+echo -e "$(echo "$msg" | sed -E 's/```(plaintext|markdown|text|diff|bash|shell)?//g' | sed 's/```//g' | tr -d '"')" > "$commit_msg_file"
 
 exit 0

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# 設定ファイルの読み込みとデフォルト設定
+# 優先順位: 1.プロジェクト設定 2.ユーザー設定 3.デフォルト設定
+
+# デフォルト設定値
+PROVIDER="bedrock"               # AIプロバイダー (bedrock, openai, anthropic, ollama)
+MODEL_ID="amazon.nova-pro-v1:0"  # モデルID
+AWS_REGION="us-east-1"           # AWSリージョン
+TEMPERATURE="0.5"                # 生成温度（高いほどランダム性が増す）
+MAX_TOKENS="512"                 # 最大トークン数
+TOP_P="0.9"                      # 上位確率（生成の多様性）
+LANGUAGE="ja"                    # 言語設定
+
+# プロジェクト設定を読み込み
+if [ -f ".commit-message-config" ]; then
+  # shellcheck source=./.commit-message-config
+  source ./.commit-message-config
+# ユーザー設定を読み込み
+elif [ -f "${HOME}/.commit-message-config" ]; then
+  # shellcheck source=~/.commit-message-config
+  source "${HOME}/.commit-message-config"
+fi
+
+# 環境変数が設定されている場合はそれを優先
+PROVIDER="${PROVIDER_ENV:-$PROVIDER}"
+MODEL_ID="${MODEL_ID_ENV:-$MODEL_ID}"
+AWS_REGION="${AWS_REGION_ENV:-$AWS_REGION}"
+TEMPERATURE="${TEMPERATURE_ENV:-$TEMPERATURE}"
+MAX_TOKENS="${MAX_TOKENS_ENV:-$MAX_TOKENS}"
+TOP_P="${TOP_P_ENV:-$TOP_P}"
+LANGUAGE="${LANGUAGE_ENV:-$LANGUAGE}"
+
+# Provider specific settings check
+if [ "$PROVIDER" = "openai" ] && [ -z "$OPENAI_API_KEY" ]; then
+  echo "OpenAI APIを使用するにはOPENAI_API_KEYを設定してください" >&2
+  exit 1
+fi
+
+if [ "$PROVIDER" = "anthropic" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+  echo "Anthropic APIを使用するにはANTHROPIC_API_KEYを設定してください" >&2
+  exit 1
+fi
+
+if [ "$PROVIDER" = "ollama" ] && [ -z "$OLLAMA_HOST" ]; then
+  # Default to localhost if not specified
+  OLLAMA_HOST="http://localhost:11434"
+fi
+
+# Export settings for other scripts
+export PROVIDER
+export MODEL_ID
+export AWS_REGION
+export TEMPERATURE
+export MAX_TOKENS
+export TOP_P
+export LANGUAGE
+export OLLAMA_HOST

--- a/generate_commit_message.sh
+++ b/generate_commit_message.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
 
+# 設定ファイルを読み込み
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+if [ -f "$script_dir/config.sh" ]; then
+  source "$script_dir/config.sh"
+else
+  # 設定ファイルがない場合はデフォルト値を設定
+  PROVIDER="bedrock"
+  MODEL_ID="amazon.nova-pro-v1:0"
+  AWS_REGION="us-east-1"
+  TEMPERATURE="0.5"
+  MAX_TOKENS="512"
+  TOP_P="0.9"
+  LANGUAGE="ja"
+fi
+
 git_diff=$(git diff HEAD | jq -sR .)
+prompt_lang="日本語"
+if [ "$LANGUAGE" = "en" ]; then
+  prompt_lang="英語"
+fi
+
 prompt=$(cat <<EOF | jq -sR .
-コミットメッセージを日本語で作成してください。このとき、コミットメッセージのみを返してください。コミットメッセージのprefixとして「feat: 新機能の追加」のように変更内容に応じてprefixをつけてください。プレフィックスには<prefix>タグ内の値を利用してください。
+コミットメッセージを${prompt_lang}で作成してください。このとき、コミットメッセージのみを返してください。コミットメッセージのprefixとして「feat: 新機能の追加」のように変更内容に応じてprefixをつけてください。プレフィックスには<prefix>タグ内の値を利用してください。
 <prefix>
   - fix：バグ修正
   - hotfix：クリティカルなバグ修正
@@ -70,9 +90,94 @@ feat: ホームページに検索窓を追加
 EOF
 )
 
-aws bedrock-runtime converse \
---model-id amazon.nova-pro-v1:0 \
---messages "[{\"role\":\"user\",\"content\":[{\"text\":$prompt}]},{\"role\":\"user\",\"content\":[{\"text\":$git_diff}]}]" \
---inference-config '{"maxTokens": 512, "temperature": 0.5, "topP": 0.9}' | jq -r '.output.message.content[0].text'
+# 依存コマンドの確認
+check_dependency() {
+  if ! command -v "$1" &> /dev/null; then
+    echo "エラー: $1 がインストールされていません" >&2
+    exit 1
+  fi
+}
 
-echo -e $(echo $msg | tr -d '"' | sed 's/^```//')
+check_dependency jq
+check_dependency git
+
+# ユーザーに選択されたAIプロバイダーに基づいて処理
+case "$PROVIDER" in
+  bedrock)
+    check_dependency aws
+    msg=$(aws bedrock-runtime converse \
+    --model-id "$MODEL_ID" \
+    --region "$AWS_REGION" \
+    --messages "[{\"role\":\"user\",\"content\":[{\"text\":$prompt}]},{\"role\":\"user\",\"content\":[{\"text\":$git_diff}]}]" \
+    --inference-config "{\"maxTokens\": $MAX_TOKENS, \"temperature\": $TEMPERATURE, \"topP\": $TOP_P}" | jq -r '.output.message.content[0].text')
+    ;;
+    
+  openai)
+    check_dependency curl
+    if [ -z "$OPENAI_API_KEY" ]; then
+      echo "エラー: OPENAI_API_KEYが設定されていません" >&2
+      exit 1
+    fi
+    
+    response=$(curl -s -X POST "https://api.openai.com/v1/chat/completions" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $OPENAI_API_KEY" \
+      -d "{
+        \"model\": \"$MODEL_ID\",
+        \"messages\": [
+          {\"role\": \"user\", \"content\": $(echo "$prompt" | jq -R .)},
+          {\"role\": \"user\", \"content\": $(echo "$git_diff" | jq -R .)}
+        ],
+        \"temperature\": $TEMPERATURE,
+        \"max_tokens\": $MAX_TOKENS
+      }")
+    msg=$(echo "$response" | jq -r '.choices[0].message.content')
+    ;;
+    
+  anthropic)
+    check_dependency curl
+    if [ -z "$ANTHROPIC_API_KEY" ]; then
+      echo "エラー: ANTHROPIC_API_KEYが設定されていません" >&2
+      exit 1
+    fi
+    
+    response=$(curl -s -X POST "https://api.anthropic.com/v1/messages" \
+      -H "Content-Type: application/json" \
+      -H "x-api-key: $ANTHROPIC_API_KEY" \
+      -H "anthropic-version: 2023-06-01" \
+      -d "{
+        \"model\": \"$MODEL_ID\",
+        \"messages\": [
+          {\"role\": \"user\", \"content\": $(echo "$prompt $git_diff" | jq -R .)}
+        ],
+        \"max_tokens\": $MAX_TOKENS,
+        \"temperature\": $TEMPERATURE
+      }")
+    msg=$(echo "$response" | jq -r '.content[0].text')
+    ;;
+    
+  ollama)
+    check_dependency curl
+    if [ -z "$OLLAMA_HOST" ]; then
+      OLLAMA_HOST="http://localhost:11434"
+    fi
+    
+    response=$(curl -s -X POST "$OLLAMA_HOST/api/generate" \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"model\": \"$MODEL_ID\",
+        \"prompt\": $(echo "$prompt\n\n$git_diff" | jq -R .),
+        \"temperature\": $TEMPERATURE,
+        \"stream\": false
+      }")
+    msg=$(echo "$response" | jq -r '.response')
+    ;;
+    
+  *)
+    echo "エラー: サポートされていないAIプロバイダーです: $PROVIDER" >&2
+    exit 1
+    ;;
+esac
+
+# 回答からMarkdownの記号などを除去する
+echo -e "$(echo "$msg" | sed -E 's/```(plaintext|markdown|text|diff|bash|shell)?//g' | sed 's/```//g' | tr -d '"')"


### PR DESCRIPTION
## 概要
Issue #4 で提案された複数の言語モデルサポート機能を実装しました。この変更により、Amazon Bedrock以外のAIプロバイダー（OpenAI、Anthropic、Ollama）も利用できるようになります。

## 変更内容

1. **設定ファイルの導入**
   - : AIプロバイダー、モデル、パラメーターの設定を一元管理
   - : ユーザーがカスタマイズできる設定ファイルのサンプル

2. **複数のAIプロバイダー対応**
   - Amazon Bedrock (既存): AWSのマネージドAIサービス
   - OpenAI API: GPT-3.5、GPT-4などのモデルを使用可能
   - Anthropic Claude API: Claude 3などのモデルを直接利用
   - Ollama: ローカル環境で実行可能なモデル対応

3. **スクリプトの更新**
   - : 各プロバイダーに対応
   - : 各プロバイダーに対応するよう更新

4. **ドキュメント更新**
   - 各AIプロバイダーの設定方法
   - 複数モデルの使い分け方法
   - 設定ファイルの使用方法

## テスト方法

1. 好みのAIプロバイダーを選択
2. ファイルに設定を記述
3. 必要な認証情報を設定（API KeyやAWSアカウント）
4. コミットを実行して自動生成されたメッセージを確認

## 関連Issue
Fixes #4